### PR TITLE
fix: Ubuntu 24.04 SSH port change support

### DIFF
--- a/update_ssh_config.sh
+++ b/update_ssh_config.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euo pipefail
 
 SSH_PORT=53122
 CONFIG_FILE="/etc/ssh/sshd_config"

--- a/update_ssh_config.sh
+++ b/update_ssh_config.sh
@@ -1,21 +1,44 @@
 #!/bin/bash
 
-# sshd_config path
+SSH_PORT=53122
 CONFIG_FILE="/etc/ssh/sshd_config"
 
 # backup
 cp $CONFIG_FILE "${CONFIG_FILE}.bak"
 
 # port
-sed -i 's/^#Port 22/Port 53122/' $CONFIG_FILE
+sed -i 's/^#\?Port 22$/Port '"$SSH_PORT"'/' $CONFIG_FILE
 
 # password
-sed -i 's/^#PasswordAuthentication yes/PasswordAuthentication no/' $CONFIG_FILE
+sed -i 's/^#\?PasswordAuthentication yes/PasswordAuthentication no/' $CONFIG_FILE
 sed -i 's/^#PermitEmptyPasswords no/PermitEmptyPasswords no/' $CONFIG_FILE
 
 # root login
-sed -i 's/^#PermitRootLogin yes/PermitRootLogin no/' $CONFIG_FILE
+sed -i 's/^#\?PermitRootLogin yes/PermitRootLogin no/' $CONFIG_FILE
 
-# check sshd_config syntax, then restart sshd
+# Ubuntu 24.04+ uses systemd socket activation for sshd.
+# sshd_config alone does not control the listen port; the socket unit does.
+if systemctl list-unit-files ssh.socket &>/dev/null; then
+  echo "Detected systemd socket activation (Ubuntu 24.04+). Overriding ssh.socket..."
+  mkdir -p /etc/systemd/system/ssh.socket.d
+  cat > /etc/systemd/system/ssh.socket.d/override.conf <<EOF
+[Socket]
+ListenStream=
+ListenStream=0.0.0.0:${SSH_PORT}
+ListenStream=[::]:${SSH_PORT}
+EOF
+  systemctl daemon-reload
+fi
+
+# check sshd_config syntax
 sshd -t
-systemctl restart sshd
+
+# restart: try socket-based first, then legacy sshd
+if systemctl is-active --quiet ssh.socket 2>/dev/null; then
+  systemctl restart ssh.socket
+  systemctl restart ssh.service
+else
+  systemctl restart sshd
+fi
+
+echo "SSH hardening complete. Port: $SSH_PORT"


### PR DESCRIPTION
## Summary
- Ubuntu 24.04+ では sshd が systemd socket activation で管理されるため、`sshd_config` の `Port` を変更しても反映されない問題を修正
- `ssh.socket` が存在する場合、自動で `/etc/systemd/system/ssh.socket.d/override.conf` を生成してポートを変更
- sed パターンを修正し、コメントアウト済み/アンコメント済み両方のディレクティブに対応

## Test plan
- [x] Ubuntu 24.04 VPS (contabo-claude) で実際にこの問題に遭遇し、同等の手順で解決済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)