### PR TITLE
feat: add UFW firewall setup script

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -41,6 +41,17 @@ Host {host-name}
     IdentityFile {path} # ex. ~/.ssh/id_rsa
 ```
 
+## ファイアウォール
+UFW を使って受信をデフォルト拒否し、SSH ポート (53122/tcp) のみ許可する。
+
+```
+cd setup
+chmod +x ufw-setup.sh
+sudo ./ufw-setup.sh
+```
+
+`main-setup.sh` を実行する場合は自動で含まれる。
+
 ## git
 ~/.gitconfigを書き換える
 ```gitconfig

--- a/setup/main-setup.sh
+++ b/setup/main-setup.sh
@@ -8,4 +8,8 @@ echo "Starting Zsh setup..."
 chmod +x ./zsh-setup.sh
 ./zsh-setup.sh
 
-echo "All setups are complete." 
+echo "Starting UFW firewall setup..."
+chmod +x ./ufw-setup.sh
+./ufw-setup.sh
+
+echo "All setups are complete."

--- a/setup/ufw-setup.sh
+++ b/setup/ufw-setup.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# UFW (Uncomplicated Firewall) のセットアップ
+
+# ufw がインストールされていなければインストール
+if ! command -v ufw &> /dev/null; then
+    echo "Installing ufw..."
+    sudo apt-get update
+    sudo apt-get install -y ufw
+fi
+
+# デフォルトポリシー: 受信を拒否、送信を許可
+sudo ufw default deny incoming
+sudo ufw default allow outgoing
+
+# SSH ポート 53122/tcp を許可
+sudo ufw allow 53122/tcp
+
+# ufw を有効化 (--force で対話プロンプトをスキップ)
+sudo ufw --force enable
+
+# ステータスを表示
+sudo ufw status verbose

--- a/setup/ufw-setup.sh
+++ b/setup/ufw-setup.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euo pipefail
 
 # UFW (Uncomplicated Firewall) のセットアップ
 
@@ -9,12 +10,17 @@ if ! command -v ufw &> /dev/null; then
     sudo apt-get install -y ufw
 fi
 
+# 現在の SSH ポートを sshd_config から検出 (デフォルト: 22)
+SSH_PORT=$(grep -E '^Port ' /etc/ssh/sshd_config 2>/dev/null | awk '{print $2}')
+SSH_PORT="${SSH_PORT:-22}"
+echo "Detected SSH port: ${SSH_PORT}"
+
 # デフォルトポリシー: 受信を拒否、送信を許可
 sudo ufw default deny incoming
 sudo ufw default allow outgoing
 
-# SSH ポート 53122/tcp を許可
-sudo ufw allow 53122/tcp
+# SSH ポートを許可
+sudo ufw allow "${SSH_PORT}/tcp" comment "SSH"
 
 # ufw を有効化 (--force で対話プロンプトをスキップ)
 sudo ufw --force enable


### PR DESCRIPTION
## Summary
- UFW ファイアウォールのセットアップスクリプト `setup/ufw-setup.sh` を追加
- デフォルトで受信を拒否・送信を許可し、SSH ポートのみ開放
- `setup/main-setup.sh` に統合（Docker・Zsh と並行で実行）
- `readme.md` にファイアウォールのセクションを追加

## Test plan
- [ ] 新規 Ubuntu サーバーで `setup/ufw-setup.sh` を実行し、`ufw status verbose` で SSH ポートのみ許可されていることを確認
- [ ] UFW 有効化後も SSH 接続が維持されることを確認
- [ ] `setup/main-setup.sh` をエンドツーエンドで実行し、全ステップ完了を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)