### PR TITLE
feat: add unattended-upgrades setup script

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -62,6 +62,22 @@ sudo ./ufw-setup.sh
 ```
 
 
+## 自動セキュリティアップデート
+
+unattended-upgrades を使ってセキュリティアップデートを自動適用する。
+
+```
+cd setup
+chmod +x unattended-upgrades-setup.sh
+sudo ./unattended-upgrades-setup.sh
+```
+
+設定確認:
+```
+systemctl status unattended-upgrades
+cat /etc/apt/apt.conf.d/20auto-upgrades
+```
+
 ## uv のインストール
 ```
 curl -LsSf https://astral.sh/uv/install.sh | sh

--- a/setup/main-setup.sh
+++ b/setup/main-setup.sh
@@ -12,4 +12,8 @@ echo "Starting UFW firewall setup..."
 chmod +x ./ufw-setup.sh
 ./ufw-setup.sh
 
+echo "Starting unattended-upgrades setup..."
+chmod +x ./unattended-upgrades-setup.sh
+./unattended-upgrades-setup.sh
+
 echo "All setups are complete."

--- a/setup/unattended-upgrades-setup.sh
+++ b/setup/unattended-upgrades-setup.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# unattended-upgrades のインストールと設定
+# セキュリティアップデートを自動的に適用する
+
+set -euo pipefail
+
+echo "Installing unattended-upgrades..."
+sudo apt-get update
+sudo apt-get install -y unattended-upgrades
+
+echo "Configuring automatic security updates..."
+sudo tee /etc/apt/apt.conf.d/20auto-upgrades > /dev/null <<'EOF'
+APT::Periodic::Update-Package-Lists "1";
+APT::Periodic::Unattended-Upgrade "1";
+APT::Periodic::AutocleanInterval "7";
+EOF
+
+echo "Verifying unattended-upgrades service..."
+sudo systemctl enable unattended-upgrades
+sudo systemctl status unattended-upgrades --no-pager
+
+echo "unattended-upgrades setup complete."

--- a/setup/unattended-upgrades-setup.sh
+++ b/setup/unattended-upgrades-setup.sh
@@ -18,6 +18,6 @@ EOF
 
 echo "Verifying unattended-upgrades service..."
 sudo systemctl enable unattended-upgrades
-sudo systemctl status unattended-upgrades --no-pager
+sudo systemctl is-enabled unattended-upgrades
 
 echo "unattended-upgrades setup complete."


### PR DESCRIPTION
## Summary
- 自動セキュリティアップデートのセットアップスクリプト `setup/unattended-upgrades-setup.sh` を追加
- `/etc/apt/apt.conf.d/20auto-upgrades` に日次アップデート確認・日次自動適用・週次クリーンアップを設定
- `setup/main-setup.sh` に統合（zsh-setup の後に実行）
- `readme.md` に自動セキュリティアップデートのセクションを追加

## Test plan
- [ ] 新規 Ubuntu サーバーで `setup/unattended-upgrades-setup.sh` を実行
- [ ] `/etc/apt/apt.conf.d/20auto-upgrades` の内容が期待通りであることを確認
- [ ] `systemctl is-enabled unattended-upgrades` が enabled であることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)