### PR TITLE
feat: add sudo NOPASSWD setup script

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -78,6 +78,23 @@ systemctl status unattended-upgrades
 cat /etc/apt/apt.conf.d/20auto-upgrades
 ```
 
+## sudo NOPASSWD
+
+指定ユーザーに対してパスワードなしでsudoを許可する。
+`/etc/sudoers.d/{username}` にルールを作成し、`visudo -c` で検証する。
+
+```
+sudo ./setup/sudo-nopasswd-setup.sh {username}
+```
+
+引数を省略すると現在のユーザーが対象になる。
+
+```
+sudo ./setup/sudo-nopasswd-setup.sh
+```
+
+**注意**: `main-setup.sh` には含まれていません（ユーザー名の指定が必要なオプション設定のため）。
+
 ## uv のインストール
 ```
 curl -LsSf https://astral.sh/uv/install.sh | sh

--- a/setup/sudo-nopasswd-setup.sh
+++ b/setup/sudo-nopasswd-setup.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+set -euo pipefail
+
+USERNAME="${1:-$(whoami)}"
+
+echo "Configuring sudo NOPASSWD for user: ${USERNAME}"
+
+# Verify the user exists
+if ! id "${USERNAME}" &>/dev/null; then
+    echo "Error: user '${USERNAME}' does not exist." >&2
+    exit 1
+fi
+
+# Create sudoers drop-in file
+SUDOERS_FILE="/etc/sudoers.d/${USERNAME}"
+echo "${USERNAME} ALL=(ALL) NOPASSWD:ALL" > "${SUDOERS_FILE}"
+
+# Set correct permissions (required by sudoers)
+chmod 0440 "${SUDOERS_FILE}"
+
+# Validate sudoers syntax
+if visudo -c -f "${SUDOERS_FILE}"; then
+    echo "sudo NOPASSWD configured successfully for ${USERNAME}."
+else
+    echo "Error: sudoers validation failed. Removing invalid file." >&2
+    rm -f "${SUDOERS_FILE}"
+    exit 1
+fi

--- a/setup/sudo-nopasswd-setup.sh
+++ b/setup/sudo-nopasswd-setup.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -euo pipefail
 
-USERNAME="${1:-$(whoami)}"
+USERNAME="${1:-${SUDO_USER:?\"Usage: sudo $0 <username> (or run via sudo so SUDO_USER is set)\"}}"
 
 echo "Configuring sudo NOPASSWD for user: ${USERNAME}"
 


### PR DESCRIPTION
## Summary
- sudo NOPASSWD 設定スクリプト `setup/sudo-nopasswd-setup.sh` を追加
- `/etc/sudoers.d/{username}` にドロップインファイルを作成（パーミッション 0440）
- `visudo -c` で構文検証し、失敗時はロールバック
- `readme.md` に使い方を記載
- ユーザー名引数が必要なため `main-setup.sh` には組み込まない（任意実行）

## 使い方
```
sudo ./setup/sudo-nopasswd-setup.sh {username}
```

## Test plan
- [ ] 有効なユーザー名で実行し、`/etc/sudoers.d/{username}` が作成されることを確認
- [ ] ファイルパーミッションが 0440 であることを確認
- [ ] 設定後にパスワードなしで `sudo` が使えることを確認
- [ ] 存在しないユーザー名でエラー終了することを確認
- [ ] 引数なしで `sudo` 経由実行時、`SUDO_USER` が使われることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)