### PR TITLE
feat: add fail2ban setup script

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -52,6 +52,26 @@ sudo ./ufw-setup.sh
 
 `main-setup.sh` を実行する場合は自動で含まれる。
 
+## fail2ban
+SSH ブルートフォース攻撃対策として fail2ban を導入する。
+
+```
+cd setup
+chmod +x fail2ban-setup.sh
+sudo ./fail2ban-setup.sh
+```
+
+設定内容 (`/etc/fail2ban/jail.local`):
+* ポート: 53122 (SSH カスタムポート)
+* maxretry: 5 (5回失敗で ban)
+* bantime: 3600 (1時間 ban)
+* findtime: 600 (10分以内の試行をカウント)
+
+ステータス確認:
+```
+sudo fail2ban-client status sshd
+```
+
 ## git
 ~/.gitconfigを書き換える
 ```gitconfig

--- a/setup/fail2ban-setup.sh
+++ b/setup/fail2ban-setup.sh
@@ -18,7 +18,7 @@ EOF
 
 # fail2ban の有効化・起動
 sudo systemctl enable fail2ban
-sudo systemctl start fail2ban
+sudo systemctl restart fail2ban
 
 # ステータス確認
 sudo fail2ban-client status

--- a/setup/fail2ban-setup.sh
+++ b/setup/fail2ban-setup.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# fail2ban のインストール
+sudo apt-get update
+sudo apt-get install -y fail2ban
+
+# jail.local の作成
+sudo tee /etc/fail2ban/jail.local > /dev/null <<'EOF'
+[sshd]
+enabled = true
+port = 53122
+maxretry = 5
+bantime = 3600
+findtime = 600
+EOF
+
+# fail2ban の有効化・起動
+sudo systemctl enable fail2ban
+sudo systemctl start fail2ban
+
+# ステータス確認
+sudo fail2ban-client status
+sudo fail2ban-client status sshd

--- a/setup/fail2ban-setup.sh
+++ b/setup/fail2ban-setup.sh
@@ -12,6 +12,8 @@ port = 53122
 maxretry = 5
 bantime = 3600
 findtime = 600
+# Ubuntu 24.04 uses ssh.service instead of sshd.service
+journalmatch = _SYSTEMD_UNIT=ssh.service + _COMM=sshd
 EOF
 
 # fail2ban の有効化・起動

--- a/setup/main-setup.sh
+++ b/setup/main-setup.sh
@@ -16,4 +16,8 @@ echo "Starting unattended-upgrades setup..."
 chmod +x ./unattended-upgrades-setup.sh
 ./unattended-upgrades-setup.sh
 
+echo "Starting fail2ban setup..."
+chmod +x ./fail2ban-setup.sh
+./fail2ban-setup.sh
+
 echo "All setups are complete."


### PR DESCRIPTION
## Summary
- fail2ban セットアップスクリプト `setup/fail2ban-setup.sh` を追加
- SSH ブルートフォース対策として sshd jail を設定（maxretry=5, bantime=3600s, findtime=600s）
- Ubuntu 24.04 対応: `journalmatch` に `ssh.service` を明示的に指定
- `setup/main-setup.sh` に統合（zsh-setup の後に実行）
- `readme.md` に fail2ban のセクションを追加

## Test plan
- [ ] 新規 Ubuntu サーバーで `setup/fail2ban-setup.sh` を実行
- [ ] `/etc/fail2ban/jail.local` が正しい設定で作成されていることを確認
- [ ] `fail2ban-client status sshd` で jail が有効かつ `journalmatch` が `ssh.service` であることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)