### PR TITLE
refactor: main-setup 統合 & readme 整理

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,121 +1,132 @@
-## ユーザー作成
+# サーバーセットアップ
+
+## 手順概要
+
+1. ユーザー作成・SSH 鍵登録 (手動)
+2. SSH ハードニング (手動)
+3. メインセットアップ (自動: `main-setup.sh`)
+4. 個別設定 (手動: git config, GitHub SSH 鍵, sudo NOPASSWD)
+
+---
+
+## 1. ユーザー作成
 
 ```
 sudo adduser {newuser}
-```
-
-ユーザーをsudoグループに追加する場合
-```
 sudo usermod -aG sudo {username}
 ```
 
-## 公開鍵でのログインを可能に
+### 公開鍵でのログインを可能に
 
+ローカルマシンから実行:
 ```
 ssh-copy-id {username}@{hostname or ip}
 ```
 
-## git
+## 2. SSH ハードニング
+
+ポート番号変更・パスワード認証無効化・root ログイン無効化を行う。
+
+サーバー上でこのリポジトリを clone:
 ```
 cd ~/.ssh
 ssh-keygen -t rsa
 cat id_rsa.pub
+# → GitHub に登録
 git clone git@github.com:t-nakatani/server_setup.git
 ```
 
-## sshの設定を上書き
-* ポート番号を変更
-* パスワード認証を無効化
-* 公開鍵認証を有効化
-
+SSH 設定を上書き:
 ```
 chmod +x update_ssh_config.sh
 sudo ./update_ssh_config.sh
 ```
 
+ローカルの `~/.ssh/config` に追加:
 ```
 Host {host-name}
     HostName {hostname or ip}
     User {username}
-    Port {port}
-    IdentityFile {path} # ex. ~/.ssh/id_rsa
+    Port 53122
+    IdentityFile ~/.ssh/id_rsa
 ```
 
-## ファイアウォール
-UFW を使って受信をデフォルト拒否し、SSH ポート (53122/tcp) のみ許可する。
+## 3. メインセットアップ
+
+以下を一括で実行する:
+
+| ステップ | 内容 |
+|----------|------|
+| base-setup | apt update/upgrade, 基本パッケージ (git, vim, curl, wget, unzip), タイムゾーン (Asia/Tokyo) |
+| docker-setup | Docker, Docker Compose |
+| zsh-setup | Zsh, peco, git-prompt |
+| ufw-setup | UFW ファイアウォール (SSH ポートのみ許可) |
+| fail2ban-setup | fail2ban (SSH ブルートフォース対策: maxretry=5, bantime=1h) |
+| unattended-upgrades-setup | セキュリティアップデート自動適用 |
+| uv-setup | uv (Python パッケージマネージャ) |
 
 ```
 cd setup
-chmod +x ufw-setup.sh
-sudo ./ufw-setup.sh
+chmod +x main-setup.sh
+sudo ./main-setup.sh
 ```
 
-`main-setup.sh` を実行する場合は自動で含まれる。
+### 個別実行
 
-## fail2ban
-SSH ブルートフォース攻撃対策として fail2ban を導入する。
-
+各スクリプトは単独でも実行可能:
 ```
 cd setup
-chmod +x fail2ban-setup.sh
-sudo ./fail2ban-setup.sh
+sudo ./base-setup.sh
+sudo ./docker-setup.sh
+# ...
 ```
 
-設定内容 (`/etc/fail2ban/jail.local`):
-* ポート: 53122 (SSH カスタムポート)
-* maxretry: 5 (5回失敗で ban)
-* bantime: 3600 (1時間 ban)
-* findtime: 600 (10分以内の試行をカウント)
+### ステータス確認
 
-ステータス確認:
 ```
+# UFW
+sudo ufw status verbose
+
+# fail2ban
 sudo fail2ban-client status sshd
-```
 
-## git
-~/.gitconfigを書き換える
-```gitconfig
-[user]
-    name = "My Name"
-    email = myname@example.com
-
-```
-
-
-## 自動セキュリティアップデート
-
-unattended-upgrades を使ってセキュリティアップデートを自動適用する。
-
-```
-cd setup
-chmod +x unattended-upgrades-setup.sh
-sudo ./unattended-upgrades-setup.sh
-```
-
-設定確認:
-```
-systemctl status unattended-upgrades
+# unattended-upgrades
+systemctl is-enabled unattended-upgrades
 cat /etc/apt/apt.conf.d/20auto-upgrades
+
+# Docker
+docker --version && docker compose version
+
+# uv
+uv --version
 ```
 
-## sudo NOPASSWD
+## 4. 個別設定 (手動)
 
-指定ユーザーに対してパスワードなしでsudoを許可する。
-`/etc/sudoers.d/{username}` にルールを作成し、`visudo -c` で検証する。
+### git config
+
+```
+git config --global user.name "My Name"
+git config --global user.email "myname@example.com"
+```
+
+### GitHub SSH 鍵
+
+```
+ssh-keygen -t ed25519 -C "{host-name}"
+cat ~/.ssh/id_ed25519.pub
+# → GitHub Settings → SSH and GPG keys に登録
+
+ssh-keyscan github.com >> ~/.ssh/known_hosts
+ssh -T git@github.com
+```
+
+### sudo NOPASSWD (任意)
+
+指定ユーザーに対してパスワードなしで sudo を許可する。
 
 ```
 sudo ./setup/sudo-nopasswd-setup.sh {username}
 ```
 
-引数を省略すると現在のユーザーが対象になる。
-
-```
-sudo ./setup/sudo-nopasswd-setup.sh
-```
-
-**注意**: `main-setup.sh` には含まれていません（ユーザー名の指定が必要なオプション設定のため）。
-
-## uv のインストール
-```
-curl -LsSf https://astral.sh/uv/install.sh | sh
-```
+引数省略時は `$SUDO_USER` (sudo の呼び出し元ユーザー) が対象。

--- a/setup/base-setup.sh
+++ b/setup/base-setup.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -euo pipefail
+
+echo "Updating package lists..."
+sudo apt-get update -qq
+
+echo "Upgrading installed packages..."
+sudo apt-get upgrade -y -qq
+
+echo "Installing base packages..."
+sudo apt-get install -y -qq git vim curl wget unzip
+
+echo "Setting timezone to Asia/Tokyo..."
+sudo timedatectl set-timezone Asia/Tokyo
+echo "Timezone: $(timedatectl show --property=Timezone --value)"
+
+echo "Base setup complete."

--- a/setup/main-setup.sh
+++ b/setup/main-setup.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+echo "Starting base setup (packages, timezone)..."
+chmod +x ./base-setup.sh
+./base-setup.sh
+
 echo "Starting Docker setup..."
 chmod +x ./docker-setup.sh
 ./docker-setup.sh
@@ -12,12 +16,16 @@ echo "Starting UFW firewall setup..."
 chmod +x ./ufw-setup.sh
 ./ufw-setup.sh
 
+echo "Starting fail2ban setup..."
+chmod +x ./fail2ban-setup.sh
+./fail2ban-setup.sh
+
 echo "Starting unattended-upgrades setup..."
 chmod +x ./unattended-upgrades-setup.sh
 ./unattended-upgrades-setup.sh
 
-echo "Starting fail2ban setup..."
-chmod +x ./fail2ban-setup.sh
-./fail2ban-setup.sh
+echo "Starting uv setup..."
+chmod +x ./uv-setup.sh
+./uv-setup.sh
 
 echo "All setups are complete."

--- a/setup/uv-setup.sh
+++ b/setup/uv-setup.sh
@@ -1,13 +1,18 @@
 #!/bin/bash
 set -euo pipefail
 
-echo "Installing uv..."
-curl -LsSf https://astral.sh/uv/install.sh | sh
+# sudo 経由の場合は呼び出し元ユーザーにインストール
+TARGET_USER="${SUDO_USER:-$(whoami)}"
+TARGET_HOME=$(eval echo "~${TARGET_USER}")
+
+echo "Installing uv for ${TARGET_USER}..."
+sudo -u "${TARGET_USER}" bash -c 'curl -LsSf https://astral.sh/uv/install.sh | sh'
 
 # .zshrc に PATH を追加（未追加の場合のみ）
-ZSHRC="${HOME}/.zshrc"
+ZSHRC="${TARGET_HOME}/.zshrc"
 if [ -f "$ZSHRC" ] && ! grep -q 'local/bin/env' "$ZSHRC"; then
     echo 'source $HOME/.local/bin/env' >> "$ZSHRC"
+    chown "${TARGET_USER}:${TARGET_USER}" "$ZSHRC"
     echo "Added uv to .zshrc PATH"
 fi
 

--- a/setup/uv-setup.sh
+++ b/setup/uv-setup.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -euo pipefail
+
+echo "Installing uv..."
+curl -LsSf https://astral.sh/uv/install.sh | sh
+
+# .zshrc に PATH を追加（未追加の場合のみ）
+ZSHRC="${HOME}/.zshrc"
+if [ -f "$ZSHRC" ] && ! grep -q 'local/bin/env' "$ZSHRC"; then
+    echo 'source $HOME/.local/bin/env' >> "$ZSHRC"
+    echo "Added uv to .zshrc PATH"
+fi
+
+echo "uv setup complete."


### PR DESCRIPTION
## Summary
- `base-setup.sh` を追加: apt update/upgrade、基本パッケージ (git, vim, curl, wget, unzip)、タイムゾーン (Asia/Tokyo)
- `uv-setup.sh` を追加: uv インストール + .zshrc への PATH 追加
- `main-setup.sh` に上記2つを統合し、実行順序を整理
- `readme.md` を実際のセットアップフロー順に再構成:
  1. ユーザー作成・SSH 鍵 (手動)
  2. SSH ハードニング (手動)
  3. メインセットアップ (自動: `main-setup.sh` で一括)
  4. 個別設定 (手動: git config, GitHub SSH 鍵, sudo NOPASSWD)

## 変更の動機
- apt update や TZ 設定など、毎回手動で行っていた手順がドキュメントにも main-setup にも含まれていなかった
- uv インストールが readme に記載はあったが main-setup に未統合だった
- readme のセクション順序が実際の作業フローと一致しておらず、散らばっていた

## Test plan
- [ ] 新規サーバーで `sudo ./setup/main-setup.sh` を実行し、全ステップが順番に完了することを確認
- [ ] `base-setup.sh` 単独実行で基本パッケージとTZが設定されることを確認
- [ ] `uv-setup.sh` 単独実行で uv がインストールされ .zshrc に PATH が追加されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)