### PR TITLE
feat: VPS セキュリティハードニング

### DIFF
--- a/docs/security_hardening.md
+++ b/docs/security_hardening.md
@@ -1,0 +1,118 @@
+# セキュリティハードニング
+
+Bot 運用 VPS のセキュリティ対策。現状の評価と改善方針をまとめる。
+
+## 現状のセキュリティスタック
+
+| レイヤー | 対策 | 設定 |
+|----------|------|------|
+| SSH | ポート変更 | 53122 |
+| SSH | 公開鍵認証のみ (ed25519) | `AuthenticationMethods publickey` |
+| SSH | root ログイン禁止 | `PermitRootLogin no` |
+| SSH | 追加ハードニング | `MaxAuthTries 3`, `LoginGraceTime 30`, X11/TCP/AgentForwarding 無効 |
+| Firewall | UFW | SSH ポートのみ許可、デフォルト deny incoming |
+| Firewall | Docker iptables 無効化 | `daemon.json` で `"iptables": false` |
+| IPS | fail2ban | SSH ブルートフォース対策 |
+| OS | unattended-upgrades | セキュリティパッチ自動適用 |
+
+## Docker と UFW のバイパス問題
+
+Docker は UFW をバイパスして iptables を直接操作する。つまり `ufw deny` していても Docker が公開したポートはインターネットからアクセス可能になる。
+
+**対策**: `/etc/docker/daemon.json` に `"iptables": false` を設定。`docker-setup.sh` で自動適用される。
+
+**現状のリスク評価**: 本番 Bot の docker-compose.yml は全てポート公開なし（2026-03 時点、19ファイル中ポート公開は tutorial の Jupyter のみ）。実害リスクは低いが、予防的に設定済み。
+
+## ユーザー権限分離
+
+### 方針: deploy と admin-agent の2ユーザー体制
+
+| ユーザー | 用途 | 権限 |
+|----------|------|------|
+| **deploy** | Bot デプロイ・運用 | docker グループのみ。sudo なし |
+| **admin-agent** | ライブラリインストール・システム管理（Claude エージェント用） | sudo NOPASSWD:ALL + docker |
+
+### 経緯
+
+当初 deploy ユーザーに `NOPASSWD:ALL` を付与していたが、日常運用で sudo は不要（CLAUDE.md でも「sudo 禁止」方針）。ライブラリインストール等のシステム管理は頻度が低く、専用ユーザーに分離することで deploy 侵害時の影響を抑える。
+
+### 検討した選択肢（deploy の sudo について）
+
+| 方針 | 内容 | 評価 |
+|------|------|------|
+| A. 削除 | NOPASSWD をやめてパスワード入力必須に | sudo 自体が不要なら中途半端 |
+| B. コマンド限定 | `systemctl restart docker` 等だけ許可 | 洗い出しが必要 |
+| C. 現状維持 | 利便性優先 | docker グループ ≒ root なので差は小さい |
+| **D. 権限分離** | **deploy から sudo を完全剥奪、admin-agent に移管** | **採用** |
+
+### セットアップ手順
+
+```bash
+# 1. admin-agent ユーザーを作成
+sudo ./setup/admin-agent-setup.sh deploy
+
+# 2. deploy ユーザーから sudo 権限を剥奪
+sudo ./setup/deploy-lockdown.sh deploy
+
+# 3. 検証
+su - deploy -c "sudo -l"   # → 「許可されていません」
+su - admin-agent -c "sudo whoami"  # → root
+```
+
+### docker グループ ≒ root の注意
+
+deploy ユーザーは docker グループに残るため、`docker run -v /:/host ...` でホスト全体にアクセス可能。これは Bot 運用に docker が必須なためのトレードオフ。根本的に解決するには rootless Docker への移行が必要（後述）。
+
+## アカウント侵害の想定シナリオ
+
+NOPASSWD:ALL が問題になるのは deploy ユーザーが侵害されたとき。Bot 運用 VPS で現実的な経路:
+
+### 1. SSH 秘密鍵の漏洩（最も現実的）
+- ローカル Mac のマルウェア感染で `~/.ssh/id_ed25519` が窃取される
+- バックアップや dotfiles リポジトリへの秘密鍵混入
+
+### 2. サプライチェーン経由
+- `pip install` / `npm install` / `curl | sh` で入れたツールに悪意あるコード
+- Docker イメージの依存関係に仕込まれたバックドア
+
+### 3. コンテナからのエスケープ
+- Docker コンテナ内の脆弱性や設定ミス（`--privileged` 等）でホスト権限取得
+
+### 4. GitHub 経由
+- GitHub アカウント侵害 → 悪意あるコード push → VPS で `git pull` + deploy 時に実行
+
+### 侵害時の影響差
+
+| NOPASSWD なし | NOPASSWD:ALL あり |
+|---|---|
+| deploy ユーザー権限のみ。Docker 操作・ファイル読み書きは可能だが、OS 設定変更やカーネル操作は不可 | `sudo su -` で即 root。SSH 設定変更、バックドア設置、ログ消去、カーネルモジュール挿入など全て可能 |
+
+ただし docker グループがある限り、NOPASSWD の有無に関わらず実質的に root 相当のアクセスが可能。
+
+## Rootless Docker 移行（将来検討）
+
+docker グループ ≒ root 問題の根本解決策。次回サーバー新規セットアップ時に導入を推奨。
+
+### 概要
+- Docker デーモンをユーザー空間で実行し、root 権限を一切使わない
+- コンテナ侵害 → ホスト root 奪取の経路を遮断
+
+### 移行手順
+1. 通常の Docker デーモンを停止
+2. `dockerd-rootless-setuptool.sh install` を実行
+3. イメージの再 pull / コンテナの再作成
+
+### Bot 運用での注意点
+
+| 項目 | 影響 |
+|------|------|
+| 特権ポート (< 1024) | bind 不可。Bot は外部 listen しないので問題なし |
+| ネットワーク性能 | slirp4netns 経由で若干のレイテンシ増加。API 通信には誤差レベル |
+| cgroup v2 必須 | Ubuntu 22.04+ なら対応済み。VPS の OS バージョンを確認 |
+| systemd サービス管理 | `systemctl --user` に変わる。自動起動設定の書き直しが必要 |
+| 既存コンテナ・ボリューム | 引き継げない。再作成が必要 |
+| Taskfile | docker コマンドのソケット指定に微修正が必要な場合あり |
+
+### 推奨タイミング
+- 既存 VPS での移行: 全 Bot のダウンタイム + 動作確認が必要で工数中
+- **新規サーバーセットアップ時にデフォルトで rootless を採用** するのが最もスムーズ

--- a/readme.md
+++ b/readme.md
@@ -3,9 +3,11 @@
 ## 手順概要
 
 1. ユーザー作成・SSH 鍵登録 (手動)
-2. SSH ハードニング (手動)
-3. メインセットアップ (自動: `main-setup.sh`)
-4. 個別設定 (手動: git config, GitHub SSH 鍵, sudo NOPASSWD)
+2. sudo NOPASSWD 設定 (手動) ← **SSH ハードニング前に必須**
+3. SSH ハードニング (手動)
+4. メインセットアップ (自動: `main-setup.sh`)
+5. 個別設定 (手動: git config, GitHub SSH 鍵)
+6. 権限分離 (admin-agent / deploy lockdown)
 
 ---
 
@@ -23,7 +25,15 @@ sudo usermod -aG sudo {username}
 ssh-copy-id {username}@{hostname or ip}
 ```
 
-## 2. SSH ハードニング
+## 2. sudo NOPASSWD 設定
+
+**重要**: SSH ハードニング (Step 3) で root ログインが無効化されるため、先に deploy ユーザーへ sudo NOPASSWD を付与する。これを忘れると管理操作が不能になり、VNC コンソールからの復旧が必要になる。
+
+```
+sudo ./setup/sudo-nopasswd-setup.sh deploy
+```
+
+## 3. SSH ハードニング
 
 ポート番号変更・パスワード認証無効化・root ログイン無効化を行う。
 
@@ -51,7 +61,7 @@ Host {host-name}
     IdentityFile ~/.ssh/id_ed25519
 ```
 
-## 3. メインセットアップ
+## 4. メインセットアップ
 
 以下を一括で実行する:
 
@@ -101,7 +111,7 @@ docker --version && docker compose version
 uv --version
 ```
 
-## 4. 個別設定 (手動)
+## 5. 個別設定 (手動)
 
 ### git config
 
@@ -121,9 +131,10 @@ ssh-keyscan github.com >> ~/.ssh/known_hosts
 ssh -T git@github.com
 ```
 
-### ユーザー権限分離
+## 6. ユーザー権限分離
 
 Bot 運用 (deploy) とシステム管理 (admin-agent) を分離する。
+Step 4 のメインセットアップ完了後に実行する。
 
 ```bash
 # 1. admin-agent ユーザーを作成（sudo NOPASSWD:ALL + deploy の SSH 鍵をコピー）

--- a/readme.md
+++ b/readme.md
@@ -61,7 +61,7 @@ Host {host-name}
 | docker-setup | Docker, Docker Compose |
 | zsh-setup | Zsh, peco, git-prompt |
 | ufw-setup | UFW ファイアウォール (SSH ポートのみ許可) |
-| fail2ban-setup | fail2ban (SSH ブルートフォース対策: maxretry=5, bantime=1h) |
+| fail2ban-setup | fail2ban (SSH ブルートフォース対策: 3回失敗で24h BAN, UFW 連携) |
 | unattended-upgrades-setup | セキュリティアップデート自動適用 |
 | uv-setup | uv (Python パッケージマネージャ) |
 

--- a/readme.md
+++ b/readme.md
@@ -30,8 +30,8 @@ ssh-copy-id {username}@{hostname or ip}
 サーバー上でこのリポジトリを clone:
 ```
 cd ~/.ssh
-ssh-keygen -t rsa
-cat id_rsa.pub
+ssh-keygen -t ed25519 -C "$(hostname)-github"
+cat id_ed25519.pub
 # → GitHub に登録
 git clone git@github.com:t-nakatani/server_setup.git
 ```
@@ -48,7 +48,7 @@ Host {host-name}
     HostName {hostname or ip}
     User {username}
     Port 53122
-    IdentityFile ~/.ssh/id_rsa
+    IdentityFile ~/.ssh/id_ed25519
 ```
 
 ## 3. メインセットアップ
@@ -121,12 +121,37 @@ ssh-keyscan github.com >> ~/.ssh/known_hosts
 ssh -T git@github.com
 ```
 
-### sudo NOPASSWD (任意)
+### ユーザー権限分離
 
-指定ユーザーに対してパスワードなしで sudo を許可する。
+Bot 運用 (deploy) とシステム管理 (admin-agent) を分離する。
 
+```bash
+# 1. admin-agent ユーザーを作成（sudo NOPASSWD:ALL + deploy の SSH 鍵をコピー）
+sudo ./setup/admin-agent-setup.sh deploy
+
+# 2. deploy ユーザーから sudo 権限を剥奪
+sudo ./setup/deploy-lockdown.sh deploy
 ```
-sudo ./setup/sudo-nopasswd-setup.sh {username}
+
+| ユーザー | 用途 | 権限 |
+|----------|------|------|
+| deploy | Bot デプロイ・運用 | docker グループのみ |
+| admin-agent | ライブラリインストール・システム管理 | sudo NOPASSWD:ALL + docker |
+
+ローカルの `~/.ssh/config` に追加:
+```
+Host {host-name}-admin
+    HostName {hostname or ip}
+    User admin-agent
+    Port 53122
+    IdentityFile ~/.ssh/id_ed25519
 ```
 
-引数省略時は `$SUDO_USER` (sudo の呼び出し元ユーザー) が対象。
+> **Note**: `sudo-nopasswd-setup.sh` は汎用スクリプトとして残してあるが、
+> 通常は上記の権限分離手順を使うこと。
+
+## ドキュメント
+
+| ドキュメント | 内容 |
+|-------------|------|
+| [docs/security_hardening.md](docs/security_hardening.md) | セキュリティ対策の全体像・方針・将来検討事項 |

--- a/setup/admin-agent-setup.sh
+++ b/setup/admin-agent-setup.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+set -euo pipefail
+
+# admin-agent ユーザーの作成
+# - sudo NOPASSWD:ALL 権限を付与
+# - deploy ユーザーの SSH 公開鍵をコピー（同じ鍵でログイン可能）
+# - docker グループに追加（メンテナンス用）
+#
+# Usage: sudo ./admin-agent-setup.sh [deploy_username]
+#   deploy_username: SSH 鍵のコピー元ユーザー (デフォルト: deploy)
+
+ADMIN_USER="admin-agent"
+DEPLOY_USER="${1:-deploy}"
+
+# --- ユーザー作成 ---
+if id "${ADMIN_USER}" &>/dev/null; then
+    echo "User '${ADMIN_USER}' already exists. Skipping creation."
+else
+    echo "Creating user '${ADMIN_USER}'..."
+    adduser --disabled-password --gecos "Admin Agent" "${ADMIN_USER}"
+fi
+
+# --- sudo グループ追加 ---
+echo "Adding '${ADMIN_USER}' to sudo group..."
+usermod -aG sudo "${ADMIN_USER}"
+
+# --- sudo NOPASSWD 設定 ---
+echo "Configuring sudo NOPASSWD for '${ADMIN_USER}'..."
+SUDOERS_FILE="/etc/sudoers.d/${ADMIN_USER}"
+echo "${ADMIN_USER} ALL=(ALL) NOPASSWD:ALL" > "${SUDOERS_FILE}"
+chmod 0440 "${SUDOERS_FILE}"
+
+if visudo -c -f "${SUDOERS_FILE}"; then
+    echo "sudoers validated."
+else
+    echo "Error: sudoers validation failed." >&2
+    rm -f "${SUDOERS_FILE}"
+    exit 1
+fi
+
+# --- docker グループ追加 ---
+if getent group docker &>/dev/null; then
+    echo "Adding '${ADMIN_USER}' to docker group..."
+    usermod -aG docker "${ADMIN_USER}"
+fi
+
+# --- SSH 公開鍵をコピー ---
+DEPLOY_HOME=$(eval echo "~${DEPLOY_USER}")
+ADMIN_HOME=$(eval echo "~${ADMIN_USER}")
+DEPLOY_KEYS="${DEPLOY_HOME}/.ssh/authorized_keys"
+
+if [ -f "${DEPLOY_KEYS}" ]; then
+    echo "Copying SSH authorized_keys from '${DEPLOY_USER}'..."
+    mkdir -p "${ADMIN_HOME}/.ssh"
+    cp "${DEPLOY_KEYS}" "${ADMIN_HOME}/.ssh/authorized_keys"
+    chown -R "${ADMIN_USER}:${ADMIN_USER}" "${ADMIN_HOME}/.ssh"
+    chmod 700 "${ADMIN_HOME}/.ssh"
+    chmod 600 "${ADMIN_HOME}/.ssh/authorized_keys"
+else
+    echo "Warning: ${DEPLOY_KEYS} not found. Set up SSH keys manually." >&2
+fi
+
+# --- シェル設定 ---
+echo "Setting default shell to bash for '${ADMIN_USER}'..."
+chsh -s /bin/bash "${ADMIN_USER}"
+
+echo ""
+echo "=== admin-agent setup complete ==="
+echo "  User:   ${ADMIN_USER}"
+echo "  Groups: sudo, docker"
+echo "  Sudo:   NOPASSWD:ALL"
+echo "  SSH:    copied from ${DEPLOY_USER}"
+echo ""
+echo "Test login: ssh -p 53122 ${ADMIN_USER}@<host>"

--- a/setup/deploy-lockdown.sh
+++ b/setup/deploy-lockdown.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+set -euo pipefail
+
+# deploy ユーザーから不要な権限を剥奪する
+# - sudo グループから除外
+# - sudoers NOPASSWD 設定を削除
+# - docker グループは維持（Bot 運用に必要）
+#
+# Usage: sudo ./deploy-lockdown.sh [username]
+#   username: 対象ユーザー (デフォルト: deploy)
+#
+# 前提: admin-agent ユーザーが既に作成済みであること
+#        (admin-agent-setup.sh を先に実行)
+
+TARGET_USER="${1:-deploy}"
+
+# --- 前提チェック ---
+if ! id "admin-agent" &>/dev/null; then
+    echo "Error: admin-agent user does not exist." >&2
+    echo "Run admin-agent-setup.sh first." >&2
+    exit 1
+fi
+
+if ! id "${TARGET_USER}" &>/dev/null; then
+    echo "Error: user '${TARGET_USER}' does not exist." >&2
+    exit 1
+fi
+
+echo "Locking down '${TARGET_USER}'..."
+
+# --- sudo グループから除外 ---
+if id -nG "${TARGET_USER}" | grep -qw sudo; then
+    echo "Removing '${TARGET_USER}' from sudo group..."
+    gpasswd -d "${TARGET_USER}" sudo
+else
+    echo "'${TARGET_USER}' is not in sudo group. Skipping."
+fi
+
+# --- sudoers NOPASSWD 設定を削除 ---
+SUDOERS_FILE="/etc/sudoers.d/${TARGET_USER}"
+if [ -f "${SUDOERS_FILE}" ]; then
+    echo "Removing sudoers file: ${SUDOERS_FILE}"
+    rm -f "${SUDOERS_FILE}"
+else
+    echo "No sudoers file found for '${TARGET_USER}'. Skipping."
+fi
+
+# --- 残っているグループを確認 ---
+echo ""
+echo "=== deploy lockdown complete ==="
+echo "  User:   ${TARGET_USER}"
+echo "  Groups: $(id -nG "${TARGET_USER}")"
+echo ""
+echo "Verify: try 'sudo -l' as ${TARGET_USER} — should be denied."

--- a/setup/docker-setup.sh
+++ b/setup/docker-setup.sh
@@ -1,17 +1,26 @@
 #!/bin/bash
+set -euo pipefail
 
-# Docker のインストール
+# Docker のインストール (Compose V2 同梱)
 curl -fsSL https://get.docker.com -o get-docker.sh
 chmod +x get-docker.sh
 ./get-docker.sh
+rm -f get-docker.sh
+
+# Docker が UFW をバイパスして iptables を直接操作するのを防ぐ
+sudo mkdir -p /etc/docker
+sudo tee /etc/docker/daemon.json > /dev/null <<'EOF'
+{
+  "iptables": false
+}
+EOF
 
 # ユーザーを docker グループに追加
-sudo usermod -aG docker $USER
-newgrp docker
+sudo usermod -aG docker "${SUDO_USER:-$USER}"
 
-# Docker Compose のインストール
-sudo curl -L "https://github.com/docker/compose/releases/download/1.29.2/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
-sudo chmod +x /usr/local/bin/docker-compose
+# Docker 再起動して daemon.json を反映
+sudo systemctl restart docker
 
-# Docker Compose のバージョン確認
-docker compose version 
+# バージョン確認
+docker --version
+docker compose version

--- a/setup/docker-setup.sh
+++ b/setup/docker-setup.sh
@@ -7,11 +7,14 @@ chmod +x get-docker.sh
 ./get-docker.sh
 rm -f get-docker.sh
 
-# Docker が UFW をバイパスして iptables を直接操作するのを防ぐ
+# Docker デーモンのセキュリティ設定
+# - iptables: false → UFW バイパスを防止
+# - no-new-privileges: true → 全コンテナで権限昇格を禁止
 sudo mkdir -p /etc/docker
 sudo tee /etc/docker/daemon.json > /dev/null <<'EOF'
 {
-  "iptables": false
+  "iptables": false,
+  "no-new-privileges": true
 }
 EOF
 

--- a/setup/fail2ban-setup.sh
+++ b/setup/fail2ban-setup.sh
@@ -1,17 +1,24 @@
 #!/bin/bash
+set -euo pipefail
 
 # fail2ban のインストール
 sudo apt-get update
 sudo apt-get install -y fail2ban
 
+# SSH ポートを sshd_config から自動検出（デフォルト: 22）
+SSH_PORT=$(grep -E '^Port ' /etc/ssh/sshd_config 2>/dev/null | awk '{print $2}')
+SSH_PORT="${SSH_PORT:-22}"
+echo "Detected SSH port: ${SSH_PORT}"
+
 # jail.local の作成
-sudo tee /etc/fail2ban/jail.local > /dev/null <<'EOF'
+sudo tee /etc/fail2ban/jail.local > /dev/null <<EOF
 [sshd]
 enabled = true
-port = 53122
-maxretry = 5
-bantime = 3600
-findtime = 600
+port = ${SSH_PORT}
+maxretry = 3
+bantime = 86400
+findtime = 3600
+banaction = ufw
 # Ubuntu 24.04 uses ssh.service instead of sshd.service
 journalmatch = _SYSTEMD_UNIT=ssh.service + _COMM=sshd
 EOF

--- a/setup/fail2ban-setup.sh
+++ b/setup/fail2ban-setup.sh
@@ -6,7 +6,7 @@ sudo apt-get update
 sudo apt-get install -y fail2ban
 
 # SSH ポートを sshd_config から自動検出（デフォルト: 22）
-SSH_PORT=$(grep -E '^Port ' /etc/ssh/sshd_config 2>/dev/null | awk '{print $2}')
+SSH_PORT=$(grep -E '^Port ' /etc/ssh/sshd_config 2>/dev/null | head -1 | awk '{print $2}')
 SSH_PORT="${SSH_PORT:-22}"
 echo "Detected SSH port: ${SSH_PORT}"
 

--- a/setup/ufw-setup.sh
+++ b/setup/ufw-setup.sh
@@ -11,7 +11,7 @@ if ! command -v ufw &> /dev/null; then
 fi
 
 # 現在の SSH ポートを sshd_config から検出 (デフォルト: 22)
-SSH_PORT=$(grep -E '^Port ' /etc/ssh/sshd_config 2>/dev/null | awk '{print $2}')
+SSH_PORT=$(grep -E '^Port ' /etc/ssh/sshd_config 2>/dev/null | head -1 | awk '{print $2}')
 SSH_PORT="${SSH_PORT:-22}"
 echo "Detected SSH port: ${SSH_PORT}"
 

--- a/update_ssh_config.sh
+++ b/update_ssh_config.sh
@@ -3,19 +3,48 @@ set -euo pipefail
 
 SSH_PORT=53122
 CONFIG_FILE="/etc/ssh/sshd_config"
+HARDENING_TAG="# --- server_setup hardening ---"
 
-# backup
-cp $CONFIG_FILE "${CONFIG_FILE}.bak"
+# backup (一度だけ)
+if [ ! -f "${CONFIG_FILE}.bak.original" ]; then
+  cp "$CONFIG_FILE" "${CONFIG_FILE}.bak.original"
+fi
+cp "$CONFIG_FILE" "${CONFIG_FILE}.bak"
 
-# port
-sed -i 's/^#\?Port 22$/Port '"$SSH_PORT"'/' $CONFIG_FILE
+# 既存の sed 置換（デフォルト値のコメント解除対応）
+sed -i 's/^#\?Port 22$/Port '"$SSH_PORT"'/' "$CONFIG_FILE"
+sed -i 's/^#\?PasswordAuthentication yes/PasswordAuthentication no/' "$CONFIG_FILE"
+sed -i 's/^#\?PermitRootLogin yes/PermitRootLogin no/' "$CONFIG_FILE"
+sed -i 's/^#\?PermitRootLogin prohibit-password/PermitRootLogin no/' "$CONFIG_FILE"
 
-# password
-sed -i 's/^#\?PasswordAuthentication yes/PasswordAuthentication no/' $CONFIG_FILE
-sed -i 's/^#PermitEmptyPasswords no/PermitEmptyPasswords no/' $CONFIG_FILE
+# 以前のハードニングブロックがあれば削除して再生成
+sed -i "/${HARDENING_TAG}/,\$d" "$CONFIG_FILE"
 
-# root login
-sed -i 's/^#\?PermitRootLogin yes/PermitRootLogin no/' $CONFIG_FILE
+# 追加ハードニング設定を末尾に追記（sed 漏れがあってもここで確実に上書き）
+cat >> "$CONFIG_FILE" <<EOF
+${HARDENING_TAG}
+Port ${SSH_PORT}
+
+# 認証
+PubkeyAuthentication yes
+AuthenticationMethods publickey
+PasswordAuthentication no
+PermitEmptyPasswords no
+ChallengeResponseAuthentication no
+UsePAM no
+PermitRootLogin no
+MaxAuthTries 3
+LoginGraceTime 30
+
+# 不要な機能を無効化
+X11Forwarding no
+AllowTcpForwarding no
+AllowAgentForwarding no
+PermitTunnel no
+
+# バナー情報の抑制
+DebianBanner no
+EOF
 
 # Ubuntu 24.04+ uses systemd socket activation for sshd.
 # sshd_config alone does not control the listen port; the socket unit does.

--- a/update_ssh_config.sh
+++ b/update_ssh_config.sh
@@ -11,14 +11,14 @@ if [ ! -f "${CONFIG_FILE}.bak.original" ]; then
 fi
 cp "$CONFIG_FILE" "${CONFIG_FILE}.bak"
 
-# 既存の sed 置換（デフォルト値のコメント解除対応）
-sed -i 's/^#\?Port 22$/Port '"$SSH_PORT"'/' "$CONFIG_FILE"
-sed -i 's/^#\?PasswordAuthentication yes/PasswordAuthentication no/' "$CONFIG_FILE"
-sed -i 's/^#\?PermitRootLogin yes/PermitRootLogin no/' "$CONFIG_FILE"
-sed -i 's/^#\?PermitRootLogin prohibit-password/PermitRootLogin no/' "$CONFIG_FILE"
-
 # 以前のハードニングブロックがあれば削除して再生成
 sed -i "/${HARDENING_TAG}/,\$d" "$CONFIG_FILE"
+
+# 既存の Port / PasswordAuthentication / PermitRootLogin 行を全て削除
+# （ハードニングブロックで一元管理するため、重複を防ぐ）
+sed -i '/^#\?Port /d' "$CONFIG_FILE"
+sed -i '/^#\?PasswordAuthentication /d' "$CONFIG_FILE"
+sed -i '/^#\?PermitRootLogin /d' "$CONFIG_FILE"
 
 # 追加ハードニング設定を末尾に追記（sed 漏れがあってもここで確実に上書き）
 cat >> "$CONFIG_FILE" <<EOF


### PR DESCRIPTION
## 概要

Bot 運用 VPS のセキュリティを強化する。

## 変更内容

### Docker
- UFW バイパス防止: `daemon.json` に `"iptables": false` を設定
- 全コンテナで権限昇格を禁止: `"no-new-privileges": true` をデーモンレベルで適用
- EOL の Compose V1 手動インストールを削除（Docker 同梱の V2 を使用）

### SSH ハードニング
- 鍵アルゴリズムを RSA → ed25519 に統一
- 追加ハードニング設定を末尾ブロック追記方式で確実に適用:
  - `AuthenticationMethods publickey`（公開鍵認証のみ）
  - `MaxAuthTries 3` / `LoginGraceTime 30`
  - X11 / TCP / Agent Forwarding 無効化
  - `DebianBanner no`
- 再実行可能な構造に改善（ハードニングブロックを毎回再生成）

### ユーザー権限分離
- `admin-agent` ユーザー作成スクリプト（sudo NOPASSWD:ALL + docker + SSH 鍵コピー）
- `deploy` ユーザーから sudo 権限を剥奪するスクリプト（docker グループは維持）
- 実行順の安全チェック付き（admin-agent 未作成時は deploy-lockdown を拒否）

### fail2ban 強化
- `maxretry`: 5 → 3
- `bantime`: 1h → 24h
- `findtime`: 10min → 1h
- `banaction`: デフォルト → ufw（UFW 連携）
- SSH ポートをハードコードから sshd_config 自動検出に変更

### ドキュメント
- `docs/security_hardening.md` を新規追加（方針・検討経緯・Rootless Docker 移行の将来検討）

## テスト手順

- [ ] 新規 VPS でフルセットアップ実行
- [ ] 既存 VPS で `admin-agent-setup.sh` → `deploy-lockdown.sh` の順で実行
- [ ] deploy ユーザーで `sudo -l` が拒否されることを確認
- [ ] admin-agent ユーザーで SSH ログイン + `sudo whoami` が成功することを確認
- [ ] fail2ban のステータス確認: `sudo fail2ban-client status sshd`

🤖 Generated with [Claude Code](https://claude.com/claude-code)